### PR TITLE
Add DailyWellness Flutter app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# testproject
-testproject
+# DailyWellness
+
+This repository contains a sample Flutter application called **DailyWellness**. The project demonstrates a simple wellness tracker with login, dashboard, and activity management screens. The app fetches motivational quotes from the public API at <https://favqs.com/api/qotd>.
+
+## Getting Started
+
+1. Ensure you have Flutter SDK 3.x installed.
+2. Run `flutter pub get` to install dependencies.
+3. Use `flutter run` to launch the application on an emulator or device.
+4. To build a release APK, run `flutter build apk --release` and follow the signing instructions from the Flutter documentation.
+
+## Testing
+
+Execute unit and widget tests with:
+
+```bash
+flutter test
+```
+
+## Screenshots
+
+Screenshots should be added in the `assets/` directory showing the app in portrait and landscape modes.
+
+## Known Issues
+
+- API failures are displayed as a simple error message on the dashboard.
+- The project was generated manually for demonstration and may require adjustments before production use.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'providers/activity_provider.dart';
+import 'screens/login_screen.dart';
+import 'screens/dashboard_screen.dart';
+import 'screens/add_activity_screen.dart';
+
+void main() {
+  runApp(const DailyWellnessApp());
+}
+
+class DailyWellnessApp extends StatelessWidget {
+  const DailyWellnessApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => ActivityProvider(),
+      child: MaterialApp(
+        title: 'DailyWellness',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(primarySwatch: Colors.blue),
+        initialRoute: LoginScreen.routeName,
+        routes: {
+          LoginScreen.routeName: (_) => const LoginScreen(),
+          DashboardScreen.routeName: (_) => const DashboardScreen(),
+          AddActivityScreen.routeName: (_) => const AddActivityScreen(),
+        },
+      ),
+    );
+  }
+}

--- a/lib/models/activity.dart
+++ b/lib/models/activity.dart
@@ -1,0 +1,7 @@
+class Activity {
+  final String name;
+  final String? notes;
+  final DateTime createdAt;
+
+  Activity({required this.name, this.notes}) : createdAt = DateTime.now();
+}

--- a/lib/providers/activity_provider.dart
+++ b/lib/providers/activity_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import '../models/activity.dart';
+
+class ActivityProvider extends ChangeNotifier {
+  final List<Activity> _activities = [
+    Activity(name: 'Drink water'),
+    Activity(name: 'Meditate'),
+    Activity(name: 'Walk'),
+  ];
+
+  List<Activity> get activities => List.unmodifiable(_activities);
+
+  void addActivity(String name, {String? notes}) {
+    _activities.add(Activity(name: name, notes: notes));
+    notifyListeners();
+  }
+}

--- a/lib/screens/add_activity_screen.dart
+++ b/lib/screens/add_activity_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/activity_provider.dart';
+
+class AddActivityScreen extends StatefulWidget {
+  static const routeName = '/add';
+  const AddActivityScreen({Key? key}) : super(key: key);
+
+  @override
+  State<AddActivityScreen> createState() => _AddActivityScreenState();
+}
+
+class _AddActivityScreenState extends State<AddActivityScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _notesController = TextEditingController();
+
+  void _save() {
+    if (_formKey.currentState!.validate()) {
+      context.read<ActivityProvider>().addActivity(
+            _nameController.text,
+            notes: _notesController.text.isEmpty ? null : _notesController.text,
+          );
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Activity')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Activity Name'),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Activity name required';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _notesController,
+                decoration: const InputDecoration(labelText: 'Notes'),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: _save,
+                child: const Text('Save'),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import '../providers/activity_provider.dart';
+import '../models/activity.dart';
+
+class DashboardScreen extends StatefulWidget {
+  static const routeName = '/dashboard';
+  const DashboardScreen({Key? key}) : super(key: key);
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  String? _quote;
+  bool _loading = true;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _fetchQuote();
+  }
+
+  Future<void> _fetchQuote() async {
+    setState(() { _loading = true; });
+    try {
+      final response = await http.get(Uri.parse('https://favqs.com/api/qotd'));
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        setState(() {
+          _quote = data['quote']['body'];
+          _loading = false;
+        });
+      } else {
+        setState(() { _quote = 'Failed to load quote'; _loading = false; });
+      }
+    } catch (e) {
+      setState(() { _quote = 'Error fetching quote'; _loading = false; });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final activities = context.watch<ActivityProvider>().activities;
+    final String user = ModalRoute.of(context)?.settings.arguments as String? ?? 'User';
+    final date = DateFormat.yMMMMd().add_jm().format(DateTime.now());
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: OrientationBuilder(
+        builder: (context, orientation) {
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: ListView(
+              children: [
+                Text('Hello, ' + user + '!', style: Theme.of(context).textTheme.headline6),
+                Text(date),
+                const SizedBox(height: 16),
+                Text('Wellness Tasks:', style: Theme.of(context).textTheme.subtitle1),
+                ...activities.map((Activity a) => ListTile(title: Text(a.name), subtitle: a.notes != null ? Text(a.notes!) : null)),
+                TextButton(
+                  onPressed: () => Navigator.pushNamed(context, '/add'),
+                  child: const Text('Add Activity'),
+                ),
+                const SizedBox(height: 16),
+                if (_loading)
+                  const CircularProgressIndicator()
+                else if (_quote != null)
+                  Text('"' + _quote! + '"', style: const TextStyle(fontStyle: FontStyle.italic)),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatefulWidget {
+  static const routeName = '/login';
+  const LoginScreen({Key? key}) : super(key: key);
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      Navigator.pushReplacementNamed(
+        context,
+        '/dashboard',
+        arguments: _emailController.text,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Email is required';
+                  }
+                  if (!value.contains('@') || !value.contains('.')) {
+                    return 'Enter a valid email';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Password is required';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Login'),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,21 @@
+name: daily_wellness
+version: 1.0.0
+publish_to: 'none'
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.5
+  http: ^0.13.5
+  flutter_localizations:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/

--- a/test/activity_provider_test.dart
+++ b/test/activity_provider_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:daily_wellness/providers/activity_provider.dart';
+
+void main() {
+  test('addActivity increases list length', () {
+    final provider = ActivityProvider();
+    final initial = provider.activities.length;
+    provider.addActivity('Yoga');
+    expect(provider.activities.length, initial + 1);
+  });
+}

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:daily_wellness/screens/login_screen.dart';
+
+void main() {
+  testWidgets('login form validation', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: LoginScreen()));
+
+    await tester.tap(find.text('Login'));
+    await tester.pump();
+
+    expect(find.text('Email is required'), findsOneWidget);
+    expect(find.text('Password is required'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- initialize DailyWellness sample Flutter project
- implement basic screens (login, dashboard, add activity)
- add provider-based state management
- configure dependencies
- add unit and widget tests
- update README with build instructions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6b02ee9c8320a68ed79444e5a68f